### PR TITLE
parameter files for convergence test of ScalarFieldCosmo example

### DIFF
--- a/Examples/ScalarFieldCosmo/convergence_test/params_HR.txt
+++ b/Examples/ScalarFieldCosmo/convergence_test/params_HR.txt
@@ -11,7 +11,7 @@
 # input_filename = Outputs/SourceData_chk000001.3d.hdf5
 
 # Where to put the final hdf5 file
-output_path = Outputs/
+output_path = Outputs_HR/
 output_filename = InitialDataFinal.3d.hdf5
 
 # Path for processor outputs and verbosity
@@ -25,7 +25,7 @@ output_filename = InitialDataFinal.3d.hdf5
 # diagnostic_interval = 10
 
 # Output for tracking convergence of the errors
-error_filename = Ham_and_Mom_errors
+error_filename = Ham_and_Mom_errors_HR
 
 #################################################
 # Grid parameters
@@ -33,7 +33,7 @@ error_filename = Ham_and_Mom_errors
 
 # 'N' is the number of subdivisions in each direction of a cubic box
 # 'L' is the length of the longest side of the box, dx_coarsest = L/N
-N = 64 64 64
+N = 128 128 128
 L = 128
 
 # Maximum number of times you can regrid above coarsest level
@@ -127,7 +127,7 @@ bh2_offset = 0.0 0.0 0.0
 # Mainly read in SimulationParameters.hpp
 
 # Max number of non linear iterations
-max_NL_iterations = 100 
+max_NL_iterations = 100
 
 # for periodic boundaries, it can help to deactivate the zero mode
 # to avoid the solution drifting in the linear solver steps

--- a/Examples/ScalarFieldCosmo/convergence_test/params_HR.txt
+++ b/Examples/ScalarFieldCosmo/convergence_test/params_HR.txt
@@ -16,7 +16,6 @@ output_filename = InitialDataFinal.3d.hdf5
 
 # Path for processor outputs and verbosity
 # pout_path = pout/
-# pout_filename = pout
 # verbosity = 1
 
 # Frequency of writing diagnostic files at non linear iterations

--- a/Examples/ScalarFieldCosmo/convergence_test/params_LR.txt
+++ b/Examples/ScalarFieldCosmo/convergence_test/params_LR.txt
@@ -11,7 +11,7 @@
 # input_filename = Outputs/SourceData_chk000001.3d.hdf5
 
 # Where to put the final hdf5 file
-output_path = Outputs/
+output_path = Outputs_LR/
 output_filename = InitialDataFinal.3d.hdf5
 
 # Path for processor outputs and verbosity
@@ -25,7 +25,7 @@ output_filename = InitialDataFinal.3d.hdf5
 # diagnostic_interval = 10
 
 # Output for tracking convergence of the errors
-error_filename = Ham_and_Mom_errors
+error_filename = Ham_and_Mom_errors_LR
 
 #################################################
 # Grid parameters

--- a/Examples/ScalarFieldCosmo/convergence_test/params_LR.txt
+++ b/Examples/ScalarFieldCosmo/convergence_test/params_LR.txt
@@ -16,7 +16,6 @@ output_filename = InitialDataFinal.3d.hdf5
 
 # Path for processor outputs and verbosity
 # pout_path = pout/
-# pout_filename = pout
 # verbosity = 1
 
 # Frequency of writing diagnostic files at non linear iterations

--- a/Examples/ScalarFieldCosmo/params.txt
+++ b/Examples/ScalarFieldCosmo/params.txt
@@ -16,7 +16,6 @@ output_filename = InitialDataFinal.3d.hdf5
 
 # Path for processor outputs and verbosity
 # pout_path = pout/
-# pout_filename = pout
 # verbosity = 1
 
 # Frequency of writing diagnostic files at non linear iterations


### PR DESCRIPTION
These parameter files are useful to perform a convergence test of a cosmological example with sine waves in both phi and phidot. We use periodic boundary conditions. When restarted with GRChombo the solution from GRTresna, the convergence plot should look like this:

![constraint_lineout](https://github.com/user-attachments/assets/bcbef3d5-31a0-4e34-855c-f82e2735a5f1)
