### PR TITLE
Bugfix/filling constraint bcs

### DIFF
--- a/Source/Operator/SetBCs.cpp
+++ b/Source/Operator/SetBCs.cpp
@@ -44,14 +44,14 @@ void ParseBC(FArrayBox &a_state, const Box &a_valid,
         // this will populate the multigrid boundaries according to the BCs
         // in particular it will fill cells for Aij, and updated K
         solver_boundaries.fill_constraint_box(Side::Lo, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS));
+                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
         solver_boundaries.fill_constraint_box(Side::Hi, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS));
+                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
         // Do it twice to catch corners... must be a better way
         // but for now this works
         solver_boundaries.fill_constraint_box(Side::Lo, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS));
+                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
         solver_boundaries.fill_constraint_box(Side::Hi, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS));
+                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
     }
 }

--- a/Source/Operator/SetBCs.cpp
+++ b/Source/Operator/SetBCs.cpp
@@ -43,15 +43,15 @@ void ParseBC(FArrayBox &a_state, const Box &a_valid,
 
         // this will populate the multigrid boundaries according to the BCs
         // in particular it will fill cells for Aij, and updated K
-        solver_boundaries.fill_constraint_box(Side::Lo, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
-        solver_boundaries.fill_constraint_box(Side::Hi, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
+        solver_boundaries.fill_constraint_box(
+            Side::Lo, a_state, Interval(0, NUM_CONSTRAINT_VARS - 1));
+        solver_boundaries.fill_constraint_box(
+            Side::Hi, a_state, Interval(0, NUM_CONSTRAINT_VARS - 1));
         // Do it twice to catch corners... must be a better way
         // but for now this works
-        solver_boundaries.fill_constraint_box(Side::Lo, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
-        solver_boundaries.fill_constraint_box(Side::Hi, a_state,
-                                              Interval(0, NUM_CONSTRAINT_VARS - 1));
+        solver_boundaries.fill_constraint_box(
+            Side::Lo, a_state, Interval(0, NUM_CONSTRAINT_VARS - 1));
+        solver_boundaries.fill_constraint_box(
+            Side::Hi, a_state, Interval(0, NUM_CONSTRAINT_VARS - 1));
     }
 }


### PR DESCRIPTION
This should fix the change in https://github.com/GRTLCollaboration/GRTresna/pull/5/commits/36052c33393101621c937d41ab40ec6f2d0c86ff

In particular:

<img width="730" alt="Screenshot 2024-12-07 at 09 00 19" src="https://github.com/user-attachments/assets/9b6188a9-3787-41ab-b1e6-ec5a9c5d7ce6">
