### PR TITLE
Bugfix/hardcoded zero

### DIFF
--- a/Source/Methods/CTTK.impl.hpp
+++ b/Source/Methods/CTTK.impl.hpp
@@ -98,7 +98,7 @@ void CTTK<matter_t>::solve_analytic(LevelData<FArrayBox> *a_multigrid_vars,
             Real K_0_squared =
                 24.0 * M_PI * G_Newton * emtensor.rho +
                 1.5 * A2_0 * pow(psi_0, -12.0) +
-                0.0 * 12.0 * laplacian_psi_reg * pow(psi_0, -5.0);
+                12.0 * laplacian_psi_reg * pow(psi_0, -5.0);
 
             // Set value for K
             // be careful if at a point K = 0, may have discontinuity

--- a/Source/Methods/CTTK.impl.hpp
+++ b/Source/Methods/CTTK.impl.hpp
@@ -95,10 +95,9 @@ void CTTK<matter_t>::solve_analytic(LevelData<FArrayBox> *a_multigrid_vars,
 
             // Now work out K using ansatz which sets it to (roughly)
             // the FRW value based on the local densities
-            Real K_0_squared =
-                24.0 * M_PI * G_Newton * emtensor.rho +
-                1.5 * A2_0 * pow(psi_0, -12.0) +
-                12.0 * laplacian_psi_reg * pow(psi_0, -5.0);
+            Real K_0_squared = 24.0 * M_PI * G_Newton * emtensor.rho +
+                               1.5 * A2_0 * pow(psi_0, -12.0) +
+                               12.0 * laplacian_psi_reg * pow(psi_0, -5.0);
 
             // Set value for K
             // be careful if at a point K = 0, may have discontinuity


### PR DESCRIPTION
This PR fixes a term in the CTTK method that is not zero if psi_0 does not satisfy the laplacian operator